### PR TITLE
get all results instead of the default 25 for real

### DIFF
--- a/scrape_with.py
+++ b/scrape_with.py
@@ -185,7 +185,7 @@ mutation sceneUpdate($input:SceneUpdateInput!) {
     def get_scenes_with_tag(self, tag):
         tagID = self.findTagIdWithName(tag)
         query = """query findScenes($scene_filter: SceneFilterType!) {
-  findScenes(scene_filter: $scene_filter filter: {per_page: -1}) {
+  findScenes(scene_filter: $scene_filter filter: {per_page: 0}) {
     count
     scenes {
       id


### PR DESCRIPTION
`per_page: -1` returns 1 result whereas `per_page: 0` returns them all

Without the `per_page` filter the query becomes:
```sql
SELECT DISTINCT scenes.id FROM scenes LEFT JOIN scenes_tags AS tags_join ON tags_join.scene_id = scenes.id LEFT JOIN tags ON tags_join.tag_id = tags.id WHERE tags.id IN (?) GROUP BY scenes.id  ORDER BY scenes.title COLLATE NATURAL_CS ASC, bitrate DESC, framerate DESC, scenes.rating DESC,
 scenes.duration DESC LIMIT 25 OFFSET 0 , args: [37]
```

with `per_page: -1` the query becomes:
```sql
SELECT DISTINCT scenes.id FROM scenes LEFT JOIN scenes_tags AS tags_join ON tags_join.scene_id = scenes.id LEFT JOIN tags ON tags_join.tag_id = tags.id WHERE tags.id IN (?) GROUP BY scenes.id  ORDER BY scenes.title COLLATE NATURAL_CS ASC, bitrate DESC, framerate DESC, scenes.rating DESC,
 scenes.duration DESC LIMIT 1 OFFSET 0 , args: [37]
```

with `per_page: 0` the query becomes:
```sql
SELECT DISTINCT scenes.id FROM scenes LEFT JOIN scenes_tags AS tags_join ON tags_join.scene_id = scenes.id LEFT JOIN tags ON tags_join.tag_id = tags.id WHERE tags.id IN (?) GROUP BY scenes.id  ORDER BY scenes.title COLLATE NATURAL_CS ASC, bitrate DESC, framerate DESC, scenes.rating DESC, scenes.duration DESC , args: [37]
```